### PR TITLE
fix Allowing OPML source without a category

### DIFF
--- a/app/Utilites/OpmlImporter.php
+++ b/app/Utilites/OpmlImporter.php
@@ -23,13 +23,39 @@ class OpmlImporter
 
         foreach ($feeds as $key => $group) {
             
-            // create group as Category
-            $category = Category::Create([
-                'description'       =>  $group['@attributes']['title'],
-            ]);
+            // OPML from inoreader allow to have folders or having a source without a folder so there is no outline
 
-            // populate group feeds 
-            foreach ($group['outline'] as $source) {
+            if(isset($group['outline'])){
+
+                // create group as Category
+                $category = Category::Create([
+                    'description'       =>  $group['@attributes']['title'],
+                ]);
+
+                // populate group feeds 
+                foreach ($group['outline'] as $source) {
+                    $source_details = isset($source['@attributes'])? $source['@attributes'] : $source;
+                    $result = Source::create([
+                        'name'              =>  $source_details['text'],
+                        'description'       =>  $source_details['title'],
+                        'url'               =>  $source_details['htmlUrl'],
+                        'author'            =>  '',
+                        'fetcher_kind'      =>  'rss',
+                        'fetcher_source'    =>  $source_details['xmlUrl'],
+                        'active'            =>  1,
+                        'why_deactivated'   => null,
+                        'category_id'            => $category->id
+                    ]);
+                }
+
+            }else{
+
+                $source = $group;
+
+                $category = Category::firstOrCreate([
+                    'description'       =>  'NULL',
+                ]);
+
                 $source_details = isset($source['@attributes'])? $source['@attributes'] : $source;
                 $result = Source::create([
                     'name'              =>  $source_details['text'],
@@ -42,7 +68,7 @@ class OpmlImporter
                     'why_deactivated'   => null,
                     'category_id'            => $category->id
                 ]);
-            }
+            }            
         }
     }
 }


### PR DESCRIPTION
OPML XML format allow to have a source (outline) without having a category:

```
<body>
    <outline text="Feed source" title="..." type="rss" xmlUrl="..." htmlUrl="..."/>
    <outline text="Feed source" title="..." type="rss" xmlUrl="..." htmlUrl="..."/>
    <outline text="Category" title="...">
        <outline text="Feed source" title="..." type="rss" xmlUrl="..." htmlUrl="..."/>
        <outline text="Feed source" title="..." type="rss" xmlUrl="..." htmlUrl="..."/>
    </outline>
</body>
```
